### PR TITLE
配信履歴からフォームの状態を復元する時に値設定の順番が正しくなるようにした。

### DIFF
--- a/src/fp_maneuver/core.clj
+++ b/src/fp_maneuver/core.clj
@@ -94,7 +94,7 @@
 
 (defn set-form-data [chinfo]
   (reduce-kv (fn [acc key val] (my-set key val) nil)
-             nil chinfo))
+             nil (force-array-map chinfo items)))
 
 (defn get-setting-form-data []
   (into {} (map #(vector %1 (text (setting-forms %1))) setting-items)))


### PR DESCRIPTION
起動直後、H264/FLV の配信履歴が復元された時に H265/MKV が選択されているかのような ffmpeg コマンドラインが表示されるのを直しました。

![_2017-06-02_00-34-56](https://cloud.githubusercontent.com/assets/1680210/26687794/a86b5806-472b-11e7-9804-8a0281e553c0.png)

![_2017-06-02_00-35-54](https://cloud.githubusercontent.com/assets/1680210/26687795/a8c6bf20-472b-11e7-85e1-1661b9723e96.png)
