### PR TITLE
pactl コマンドを実行して音声ソースの一覧を得るようにした。

### DIFF
--- a/src/fp_maneuver/core.clj
+++ b/src/fp_maneuver/core.clj
@@ -328,16 +328,22 @@
                          (doto (dialog :type :info :content "先にffmpeg-pathを指定して下さい。")
                            (.setLocationRelativeTo main-window)
                            pack! show!)
-                         (let [listbox (listbox :model ((get-devices) type))]
-                           (.setSelectedIndex listbox 0)
-                           (doto (dialog :title (str type "の選択")
-                                         :type :question
-                                         :content listbox
-                                         :success-fn (fn [_] (text!
-                                                              (setting-forms type)
-                                                              (selection listbox))))
-                             (.setLocationRelativeTo main-window)
-                             pack! show!))))]))
+                         (try
+                           (let [listbox (listbox :model ((get-devices) type))]
+                             (.setSelectedIndex listbox 0)
+                             (doto (dialog :title (str type "の選択")
+                                           :type :question
+                                           :content listbox
+                                           :success-fn (fn [_] (text!
+                                                                (setting-forms type)
+                                                                (selection listbox))))
+                               (.setLocationRelativeTo main-window)
+                               pack! show!))
+                           ;; ffmpeg や pactl の実行に失敗した場合。
+                           (catch java.io.IOException e
+                             (doto (dialog :type :error :content (.getMessage e))
+                               (.setLocationRelativeTo main-window)
+                               pack! show!)))))]))
 
 (load "core_component")
 


### PR DESCRIPTION
Windows 以外では pactl コマンドの出力から、音声デバイスのリストを生成するようにしました。

![_2017-06-09_12-24-43](https://user-images.githubusercontent.com/1680210/26960029-3fe3d012-4d0f-11e7-9fa7-fc78e3fc4490.png)
